### PR TITLE
feat: Implement dark mode for home page

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ app.set('view engine', 'ejs');
 app.use(cookieParser())
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(express.static('public'));
 
 app.use('/',indexRouter)
 app.use('/user', userRouter);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,21 @@
+/* Basic transition for theme changes */
+body {
+  transition: background-color 0.3s, color 0.3s;
+}
+
+/* Any other global styles that are not easily handled by adding classes directly in HTML.
+   For a Tailwind CDN project, this file might be very small or even empty if all styling
+   is done via utility classes in the HTML.
+   For now, we'll keep it minimal. We can add more specific global styles if needed.
+*/
+
+/* For example, if we want a default link color that is not Tailwind's default blue,
+   but still want it to be theme-aware, we could do:
+a {
+  color: #yourBrandLightLinkColor;
+}
+body.dark a {
+  color: #yourBrandDarkLinkColor;
+}
+   However, it's usually better to use Tailwind's text color utilities like text-blue-600 dark:text-blue-400 directly on the <a> tags.
+*/

--- a/public/js/theme-toggle.js
+++ b/public/js/theme-toggle.js
@@ -1,0 +1,61 @@
+// theme-toggle.js
+
+const themeToggleBtn = document.getElementById('theme-toggle');
+const htmlElement = document.documentElement; // Or document.body, depending on where you want to apply the 'dark' class
+const themeToggleDarkIcon = document.getElementById('theme-toggle-dark-icon');
+const themeToggleLightIcon = document.getElementById('theme-toggle-light-icon');
+
+// Function to apply the saved theme or system preference
+function applyTheme() {
+  const storedTheme = localStorage.getItem('theme');
+  const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  if (storedTheme === 'dark' || (!storedTheme && systemPrefersDark)) {
+    htmlElement.classList.add('dark');
+    if (themeToggleDarkIcon && themeToggleLightIcon) {
+      themeToggleDarkIcon.classList.remove('hidden');
+      themeToggleLightIcon.classList.add('hidden');
+    }
+  } else {
+    htmlElement.classList.remove('dark');
+    if (themeToggleDarkIcon && themeToggleLightIcon) {
+      themeToggleDarkIcon.classList.add('hidden');
+      themeToggleLightIcon.classList.remove('hidden');
+    }
+  }
+}
+
+// Apply theme on initial load
+applyTheme();
+
+// Add event listener for the toggle button
+if (themeToggleBtn) {
+  themeToggleBtn.addEventListener('click', () => {
+    if (htmlElement.classList.contains('dark')) {
+      htmlElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+      if (themeToggleDarkIcon && themeToggleLightIcon) {
+        themeToggleDarkIcon.classList.add('hidden');
+        themeToggleLightIcon.classList.remove('hidden');
+      }
+    } else {
+      htmlElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+      if (themeToggleDarkIcon && themeToggleLightIcon) {
+        themeToggleDarkIcon.classList.remove('hidden');
+        themeToggleLightIcon.classList.add('hidden');
+      }
+    }
+  });
+}
+
+// Optional: Listen for changes in system preference
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+  if (!localStorage.getItem('theme')) { // Only apply if no explicit user choice
+    if (e.matches) {
+      htmlElement.classList.add('dark');
+    } else {
+      htmlElement.classList.remove('dark');
+    }
+  }
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class', // or 'media' or 'class'
+  content: [
+    "./views/**/*.ejs", // Path to your EJS templates
+    "./public/**/*.js", // Path to your JS files (if you use Tailwind classes in JS)
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [
+    require('flowbite/plugin') // If you are using Flowbite components
+  ],
+}

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -9,58 +9,65 @@
     <link
     href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css"
     rel="stylesheet"
-/>
+    />
+    <link rel="stylesheet" href="/css/style.css">
 </head>
 
-<body class="bg-gray-800 min-h-screen p-6">
+<body class="min-h-screen p-6 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
     <div class="max-w-6xl mx-auto space-y-6 w-full">
 
         <!-- Header -->
-        <header class="flex justify-between items-center bg-white p-4 rounded shadow">
-            <h1 class="text-3xl font-bold text-gray-800">My Drive</h1>
-            <button onclick="showPopUp()"
-                class="px-4 py-2 text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow transition duration-200">
-                Upload File
-            </button>
+        <header class="flex justify-between items-center p-4 rounded shadow bg-gray-50 dark:bg-gray-700">
+            <h1 class="text-3xl font-bold text-gray-800 dark:text-white">My Drive</h1>
+            <div> <!-- Flex container for buttons -->
+                <button id="theme-toggle" type="button" class="px-3 py-2 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none rounded-lg">
+                    <svg id="theme-toggle-dark-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
+                    <svg id="theme-toggle-light-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm.001 6.071a1 1 0 10-1.414-1.414l-.706.707a1 1 0 101.414 1.414l.707-.707zM3 11a1 1 0 100-2H2a1 1 0 100 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path></svg>
+                </button>
+                <button onclick="showPopUp()"
+                    class="px-4 py-2 text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow transition duration-200 ml-2 dark:bg-blue-700 dark:hover:bg-blue-800"> 
+                    Upload File
+                </button>
+            </div>
         </header>
 
         <!-- Upload Dropzone -->
-        <section class="pop bg-white p-6 rounded-lg shadow hidden">
+        <section class="pop p-6 rounded-lg shadow hidden bg-gray-50 dark:bg-gray-700">
             <form action="/upload" method="post" enctype="multipart/form-data">
                 <div class="flex items-center justify-center w-full">
                     <label for="dropzone-file"
-                        class="flex flex-col items-center justify-center w-full h-64 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition">
+                        class="flex flex-col items-center justify-center w-full h-64 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg cursor-pointer bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 transition">
                         <div class="flex flex-col items-center justify-center pt-5 pb-6">
-                            <svg class="w-8 h-8 mb-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none"
+                            <svg class="w-8 h-8 mb-4 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none"
                                 viewBox="0 0 20 16">
                                 <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"
                                     stroke-width="2"
                                     d="M13 13h3a3 3 0 0 0 0-6h-.025A5.56 5.56 0 0 0 16 6.5 5.5 5.5 0 0 0 5.2 5C5.1 5 5 5 5 5a4 4 0 0 0 0 8h2.2M10 15V6m0 0L8 8m2-2 2 2" />
                             </svg>
-                            <p class="mb-2 text-sm text-gray-500"><span class="font-semibold">Click to upload</span> or
+                            <p class="mb-2 text-sm text-gray-500 dark:text-gray-400"><span class="font-semibold">Click to upload</span> or
                                 drag and drop</p>
-                            <p class="text-xs text-gray-500">SVG, PNG, JPG or GIF (MAX. 800x400px)</p>
+                            <p class="text-xs text-gray-500 dark:text-gray-400">SVG, PNG, JPG or GIF (MAX. 800x400px)</p>
                         </div>
                         <input id="dropzone-file" type="file" class="hidden" name="file" />
                     </label>
                 </div>
-                <button class="bg-gray-500 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded mt-4">
+                <button class="bg-gray-500 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded mt-4 dark:bg-gray-600 dark:hover:bg-gray-500">
                     Upload file
                 </button>
             </form>
             <button onclick="hidePopUp()"
-                class="bg-red-500 hover:bg-red-800 text-white font-bold py-2 px-4 rounded mt-4">
+                class="bg-red-500 hover:bg-red-800 text-white font-bold py-2 px-4 rounded mt-4 dark:bg-red-600 dark:hover:bg-red-700">
                <i class="ri-close-large-line"></i>
             </button>
         </section>
         <div class="files flex flx-col gap-2 ">
             <% files.forEach((file)=>{ %>
-            <div class="p-2 cursor-pointer rounded-md bg-gray-400 flex gap-20 justify-between items-center">
+            <div class="file-item p-2 cursor-pointer rounded-md flex gap-20 justify-between items-center bg-gray-100 dark:bg-gray-600 text-gray-800 dark:text-gray-200">
                 <h1><%= file.originalname %></h1>
 
                 <a href="/download/<%= file.path %>" 
                     download="<%= file.originalname %>"
-                    class="text-gray-800 hover:text-blue-600">
+                    class="text-gray-700 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-400">
                     <i class="ri-download-2-line"></i>
                 </a>
             </div>
@@ -69,6 +76,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.js"></script>
+    <script src="/js/theme-toggle.js"></script>
     <script>
         function showPopUp(){
             document.querySelector('.pop').style.display = 'block';        


### PR DESCRIPTION
Adds dark mode functionality to the home page (`views/home.ejs`).

Key changes include:
- Configured Tailwind CSS for class-based dark mode (`tailwind.config.js`).
- Set up a `public` directory for static assets (`css/style.css`, `js/theme-toggle.js`).
- Implemented a JavaScript theme toggle (`theme-toggle.js`) that:
    - Uses `localStorage` to persist theme choice.
    - Defaults to system preference if no choice is stored.
    - Toggles a 'dark' class on the `<html>` element.
- Modified `app.js` to serve static assets.
- Updated `views/home.ejs`:
    - Linked the stylesheet and theme toggle script.
    - Added a theme toggle button with icons in the header.
    - Adjusted Tailwind CSS classes on various elements to support light and dark themes (body, header, text, pop-ups, file list items).

Dark mode for other pages (login, register, index) is not included in this change and can be addressed in a future update.